### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/ikorecky/790d95a5-3b1f-448c-a260-90185f81d25b/d81a7641-09c2-422d-b2d0-5dd270d1b3c5/_apis/work/boardbadge/188f2abd-3a2a-491a-b1ed-f82f7fdbc4a8)](https://dev.azure.com/ikorecky/790d95a5-3b1f-448c-a260-90185f81d25b/_boards/board/t/d81a7641-09c2-422d-b2d0-5dd270d1b3c5/Microsoft.RequirementCategory)
 # CodeToCloud with GitHub and Azure DevOps Workshop - Source
 This repository contains the source code for the CodeToCloud workshop. Please follow the instructions in the [CodeToCloud-Student](https://github.com/XpiritBV/CodeToCloud-Student) repository to use this.
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/ikorecky/790d95a5-3b1f-448c-a260-90185f81d25b/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.